### PR TITLE
add context to Discover

### DIFF
--- a/upnp_test.go
+++ b/upnp_test.go
@@ -1,8 +1,10 @@
 package upnp
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestConcurrentUPNP tests that several threads calling Discover() concurrently
@@ -12,7 +14,9 @@ func TestConcurrentUPNP(t *testing.T) {
 		t.SkipNow()
 	}
 	// verify that a router exists
-	_, err := Discover()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := DiscoverCtx(ctx)
 	if err != nil {
 		t.Skip(err)
 	}
@@ -23,7 +27,9 @@ func TestConcurrentUPNP(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := Discover()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			_, err := DiscoverCtx(ctx)
 			if err != nil {
 				t.Error(err)
 			}
@@ -34,7 +40,9 @@ func TestConcurrentUPNP(t *testing.T) {
 
 func TestIGD(t *testing.T) {
 	// connect to router
-	d, err := Discover()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	d, err := DiscoverCtx(ctx)
 	if err != nil {
 		t.Skip(err)
 	}

--- a/vendor/github.com/huin/goupnp/dcps/internetgateway1/internetgateway1.go
+++ b/vendor/github.com/huin/goupnp/dcps/internetgateway1/internetgateway1.go
@@ -8,6 +8,7 @@ package internetgateway1
 // Generated file - do not edit by hand. See README.md
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -1840,9 +1841,9 @@ type WANIPConnection1 struct {
 // if the discovery process failed outright.
 //
 // This is a typical entry calling point into this package.
-func NewWANIPConnection1Clients() (clients []*WANIPConnection1, errors []error, err error) {
+func NewWANIPConnection1Clients(ctx context.Context) (clients []*WANIPConnection1, errors []error, err error) {
 	var genericClients []goupnp.ServiceClient
-	if genericClients, errors, err = goupnp.NewServiceClients(URN_WANIPConnection_1); err != nil {
+	if genericClients, errors, err = goupnp.NewServiceClientsCtx(ctx, URN_WANIPConnection_1); err != nil {
 		return
 	}
 	clients = newWANIPConnection1ClientsFromGenericClients(genericClients)
@@ -2855,9 +2856,9 @@ type WANPPPConnection1 struct {
 // if the discovery process failed outright.
 //
 // This is a typical entry calling point into this package.
-func NewWANPPPConnection1Clients() (clients []*WANPPPConnection1, errors []error, err error) {
+func NewWANPPPConnection1Clients(ctx context.Context) (clients []*WANPPPConnection1, errors []error, err error) {
 	var genericClients []goupnp.ServiceClient
-	if genericClients, errors, err = goupnp.NewServiceClients(URN_WANPPPConnection_1); err != nil {
+	if genericClients, errors, err = goupnp.NewServiceClientsCtx(ctx, URN_WANPPPConnection_1); err != nil {
 		return
 	}
 	clients = newWANPPPConnection1ClientsFromGenericClients(genericClients)

--- a/vendor/github.com/huin/goupnp/goupnp.go
+++ b/vendor/github.com/huin/goupnp/goupnp.go
@@ -15,6 +15,7 @@
 package goupnp
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -51,19 +52,24 @@ type MaybeRootDevice struct {
 	Err error
 }
 
-// DiscoverDevices attempts to find targets of the given type. This is
+// DiscoverDevices is deprecated. Use DiscoverDevicesCtx instead.
+func DiscoverDevices(searchTarget string) ([]MaybeRootDevice, error) {
+	return DiscoverDevicesCtx(context.Background(), searchTarget)
+}
+
+// DiscoverDevicesCtx attempts to find targets of the given type. This is
 // typically the entry-point for this package. searchTarget is typically a URN
 // in the form "urn:schemas-upnp-org:device:..." or
 // "urn:schemas-upnp-org:service:...". A single error is returned for errors
 // while attempting to send the query. An error or RootDevice is returned for
 // each discovered RootDevice.
-func DiscoverDevices(searchTarget string) ([]MaybeRootDevice, error) {
+func DiscoverDevicesCtx(ctx context.Context, searchTarget string) ([]MaybeRootDevice, error) {
 	httpu, err := httpu.NewHTTPUClient()
 	if err != nil {
 		return nil, err
 	}
 	defer httpu.Close()
-	responses, err := ssdp.SSDPRawSearch(httpu, string(searchTarget), 2, 3)
+	responses, err := ssdp.SSDPRawSearchCtx(ctx, httpu, string(searchTarget), 2, 3)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/huin/goupnp/service_client.go
+++ b/vendor/github.com/huin/goupnp/service_client.go
@@ -1,6 +1,7 @@
 package goupnp
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -19,12 +20,17 @@ type ServiceClient struct {
 	Service    *Service
 }
 
-// NewServiceClients discovers services, and returns clients for them. err will
+// NewServiceClients is deprecated. Use NewServiceClientsCtx instead.
+func NewServiceClients(searchTarget string) (clients []ServiceClient, errors []error, err error) {
+	return NewServiceClientsCtx(context.Background(), searchTarget)
+}
+
+// NewServiceClientsCtx discovers services, and returns clients for them. err will
 // report any error with the discovery process (blocking any device/service
 // discovery), errors reports errors on a per-root-device basis.
-func NewServiceClients(searchTarget string) (clients []ServiceClient, errors []error, err error) {
+func NewServiceClientsCtx(ctx context.Context, searchTarget string) (clients []ServiceClient, errors []error, err error) {
 	var maybeRootDevices []MaybeRootDevice
-	if maybeRootDevices, err = DiscoverDevices(searchTarget); err != nil {
+	if maybeRootDevices, err = DiscoverDevicesCtx(ctx, searchTarget); err != nil {
 		return
 	}
 

--- a/vendor/github.com/huin/goupnp/soap/soap.go
+++ b/vendor/github.com/huin/goupnp/soap/soap.go
@@ -54,7 +54,8 @@ func (client *SOAPClient) PerformAction(actionNamespace, actionName string, inAc
 	}
 	defer response.Body.Close()
 	if response.StatusCode != 200 {
-		return fmt.Errorf("goupnp: SOAP request got HTTP %s", response.Status)
+		resp, _ := ioutil.ReadAll(response.Body)
+		return fmt.Errorf("goupnp: SOAP request got HTTP %s: %s", response.Status, resp)
 	}
 
 	responseEnv := newSOAPEnvelope()

--- a/vendor/github.com/huin/goupnp/ssdp/ssdp.go
+++ b/vendor/github.com/huin/goupnp/ssdp/ssdp.go
@@ -1,6 +1,7 @@
 package ssdp
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -21,6 +22,11 @@ const (
 	methodNotify   = "NOTIFY"
 )
 
+// SSDPRawSearch is deprecated; use SSDPRawSearchCtx instead
+func SSDPRawSearch(httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds int, numSends int) ([]*http.Response, error) {
+	return SSDPRawSearchCtx(context.Background(), httpu, searchTarget, maxWaitSeconds, numSends)
+}
+
 // SSDPRawSearch performs a fairly raw SSDP search request, and returns the
 // unique response(s) that it receives. Each response has the requested
 // searchTarget, a USN, and a valid location. maxWaitSeconds states how long to
@@ -28,14 +34,14 @@ const (
 // implementation waits an additional 100ms for responses to arrive), 2 is a
 // reasonable value for this. numSends is the number of requests to send - 3 is
 // a reasonable value for this.
-func SSDPRawSearch(httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds int, numSends int) ([]*http.Response, error) {
+func SSDPRawSearchCtx(ctx context.Context, httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds int, numSends int) ([]*http.Response, error) {
 	if maxWaitSeconds < 1 {
 		return nil, errors.New("ssdp: maxWaitSeconds must be >= 1")
 	}
 
 	seenUsns := make(map[string]bool)
 	var responses []*http.Response
-	req := http.Request{
+	req := (&http.Request{
 		Method: methodSearch,
 		// TODO: Support both IPv4 and IPv6.
 		Host: ssdpUDP4Addr,
@@ -48,8 +54,8 @@ func SSDPRawSearch(httpu *httpu.HTTPUClient, searchTarget string, maxWaitSeconds
 			"MAN":  []string{ssdpDiscover},
 			"ST":   []string{searchTarget},
 		},
-	}
-	allResponses, err := httpu.Do(&req, time.Duration(maxWaitSeconds)*time.Second+100*time.Millisecond, numSends)
+	}).WithContext(ctx)
+	allResponses, err := httpu.Do(req, time.Duration(maxWaitSeconds)*time.Second+100*time.Millisecond, numSends)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Once this is merged, we can switch Sia over to using `DiscoverCtx`, which will allow faster shutdown. I imagine that we also want to add context support to the other methods, like `Forward`, `Clear`, and `ExternalIP`.

While diving into this package, I discovered one annoyance: all communication with the UPnP device will take at least 2 seconds. Even if the device responds in 10ms and sends no more data, the `httpu` package will keep waiting for 2 seconds in case more data arrives. This may be an inherent flaw in the protocol. I'll do a little digging; it would be nice if we could eliminate it.

Update: I don't think it can be eliminated. Basically, in the UPnP protocol, you broadcast a packet to any devices that might be listening, and then you wait for responses. You don't know in advance how many responses you'll get, so you can't exit early -- hence the 2 second timeout.

However, we should only have to do this broadcast once. After you've discovered your local devices, you can save the IP of your router. Then, next time, you call `upnp.Load`, which immediately connects directly to the router. We could do this in Sia pretty easily; it just amounts to saving the IP in the gateway/host persist files and loading it on startup, then falling back to a new `Discover` call if the old IP fails.