### PR TITLE
[WIP] add method to check forwarded ports

### DIFF
--- a/upnp.go
+++ b/upnp.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/NebulousLabs/fastrand"
@@ -68,18 +69,33 @@ func (d *IGD) CheckForwardUDP(port uint16) (bool, error) {
 
 // checkForward checks whether a specific TCP or UDP port is forwarded to this host
 func (d *IGD) checkForward(port uint16, proto string) (bool, error) {
+	time.Sleep(time.Millisecond)
+	_, _, enabled, _, _, errClient := d.client.GetSpecificPortMappingEntry("", port, proto)
 
-	// Magic happens here.. :-)
+	//DEBUG
+	//newPort, intClient, enabled, desc, duration, errClient := d.client.GetSpecificPortMappingEntry("", port, proto)
+	//fmt.Println("-----")
+	//fmt.Println("newPort: ", newPort)
+	//fmt.Println("intClient: ", intClient)
+	//fmt.Println("enabled: ", enabled)
+	//fmt.Println("desc: ", desc)
+	//fmt.Println("duration: ", duration)
+	//fmt.Println("err: ", errClient)
+	//fmt.Println("-----")
 
-	// Successfully determined that port is forwarded to this host
-	return true, nil
+	if errClient != nil {
+		// 714 "NoSuchEntryInArray" means that there is no such forwarding
+		matched, _ := regexp.MatchString("<errorCode>714</errorCode>", errClient.Error())
+		if matched == true {
+			return false, nil
+		}
+		return false, errClient
+	}
 
-	// Successfully determined that port is *not* forwarded to this or any other host
+	if enabled == true {
+		return true, nil
+	}
 	return false, nil
-
-	// encountered an error
-	return false, err
-
 }
 
 // Forward forwards the specified port, and adds its description to the

--- a/upnp.go
+++ b/upnp.go
@@ -30,7 +30,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/NebulousLabs/fastrand"
@@ -57,13 +57,13 @@ func (d *IGD) ExternalIP() (string, error) {
 	return d.client.GetExternalIPAddress()
 }
 
-// CheckForwardTCP checks whether a specific TCP port is forwarded to this host
-func (d *IGD) CheckForwardTCP(port uint16) (bool, error) {
+// IsForwardedTCP checks whether a specific TCP port is forwarded to this host
+func (d *IGD) IsForwardedTCP(port uint16) (bool, error) {
 	return d.checkForward(port, "TCP")
 }
 
-// CheckForwardUDP checks whether a specific UDP port is forwarded to this host
-func (d *IGD) CheckForwardUDP(port uint16) (bool, error) {
+// IsForwardedUDP checks whether a specific UDP port is forwarded to this host
+func (d *IGD) IsForwardedUDP(port uint16) (bool, error) {
 	return d.checkForward(port, "UDP")
 }
 

--- a/upnp.go
+++ b/upnp.go
@@ -45,6 +45,7 @@ type IGD struct {
 	client interface {
 		GetExternalIPAddress() (string, error)
 		AddPortMapping(string, uint16, string, uint16, string, bool, string, uint32) error
+		GetSpecificPortMappingEntry(string, uint16, string) (uint16, string, bool, string, uint32, error)
 		DeletePortMapping(string, uint16, string) error
 		GetServiceClient() *goupnp.ServiceClient
 	}
@@ -53,6 +54,24 @@ type IGD struct {
 // ExternalIP returns the router's external IP.
 func (d *IGD) ExternalIP() (string, error) {
 	return d.client.GetExternalIPAddress()
+}
+
+// CheckForwardTCP checks whether a specific TCP port is forwarded to this host
+func (d *IGD) CheckForwardTCP(port uint16) (bool, error) {
+	return d.checkForward(port, "TCP")
+}
+
+// CheckForwardUDP checks whether a specific UDP port is forwarded to this host
+func (d *IGD) CheckForwardUDP(port uint16) (bool, error) {
+	return d.checkForward(port, "UDP")
+}
+
+// checkForward checks whether a specific TCP or UDP port is forwarded to this host
+func (d *IGD) checkForward(port uint16, proto string) (bool, error) {
+
+    // Magic happens here.. :-)
+
+	return false, nil
 }
 
 // Forward forwards the specified port, and adds its description to the

--- a/upnp.go
+++ b/upnp.go
@@ -70,32 +70,17 @@ func (d *IGD) IsForwardedUDP(port uint16) (bool, error) {
 // checkForward checks whether a specific TCP or UDP port is forwarded to this host
 func (d *IGD) checkForward(port uint16, proto string) (bool, error) {
 	time.Sleep(time.Millisecond)
-	_, _, enabled, _, _, errClient := d.client.GetSpecificPortMappingEntry("", port, proto)
+	_, _, enabled, _, _, err := d.client.GetSpecificPortMappingEntry("", port, proto)
 
-	//DEBUG
-	//newPort, intClient, enabled, desc, duration, errClient := d.client.GetSpecificPortMappingEntry("", port, proto)
-	//fmt.Println("-----")
-	//fmt.Println("newPort: ", newPort)
-	//fmt.Println("intClient: ", intClient)
-	//fmt.Println("enabled: ", enabled)
-	//fmt.Println("desc: ", desc)
-	//fmt.Println("duration: ", duration)
-	//fmt.Println("err: ", errClient)
-	//fmt.Println("-----")
-
-	if errClient != nil {
+	if err != nil {
 		// 714 "NoSuchEntryInArray" means that there is no such forwarding
-		matched, _ := regexp.MatchString("<errorCode>714</errorCode>", errClient.Error())
-		if matched == true {
+		if contained := strings.Contains(err.Error(), "<errorCode>714</errorCode>"); contained == true {
 			return false, nil
 		}
-		return false, errClient
+		return false, err
 	}
 
-	if enabled == true {
-		return true, nil
-	}
-	return false, nil
+	return enabled, nil
 }
 
 // Forward forwards the specified port, and adds its description to the

--- a/upnp.go
+++ b/upnp.go
@@ -69,9 +69,17 @@ func (d *IGD) CheckForwardUDP(port uint16) (bool, error) {
 // checkForward checks whether a specific TCP or UDP port is forwarded to this host
 func (d *IGD) checkForward(port uint16, proto string) (bool, error) {
 
-    // Magic happens here.. :-)
+	// Magic happens here.. :-)
 
+	// Successfully determined that port is forwarded to this host
+	return true, nil
+
+	// Successfully determined that port is *not* forwarded to this or any other host
 	return false, nil
+
+	// encountered an error
+	return false, err
+
 }
 
 // Forward forwards the specified port, and adds its description to the

--- a/upnp_test.go
+++ b/upnp_test.go
@@ -2,6 +2,7 @@ package upnp
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -54,16 +55,40 @@ func TestIGD(t *testing.T) {
 	}
 	t.Log("Your external IP is:", ip)
 
+	// check that port 9001 is not forwarded
+	res, err := d.IsForwardedTCP(9001)
+	if err != nil {
+		t.Fatal(err)
+	} else if res == true {
+		t.Fatal(errors.New("port 9001 is already forwarded"))
+	}
+
 	// forward a port
 	err = d.Forward(9001, "upnp test")
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// check that port 9001 is now forwarded
+	res, err = d.IsForwardedTCP(9001)
+	if err != nil {
+		t.Fatal(err)
+	} else if res == false {
+		t.Fatal(errors.New("port 9001 was not reported as forwarded"))
+	}
+
 	// un-forward a port
 	err = d.Clear(9001)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// check that port 9001 is no longer forwarded
+	res, err = d.IsForwardedTCP(9001)
+	if err != nil {
+		t.Fatal(err)
+	} else if res == true {
+		t.Fatal(errors.New("port 9001 is still forwarded"))
 	}
 
 	// record router's location


### PR DESCRIPTION
As mentioned in #14 it makes sense to add a method that let's a caller check whether a given TCP or UDP port is currently forwarded to this host. The `UPnP` function `GetSpecificPortMappingEntry` can be used for this.

@lukechampine I started working on this and this really looks doable.. ;-) 
~This is currently only a stub showing the two new public and on internal methods.~ How does this look so far?